### PR TITLE
docs: update suffix of descriptor in example

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,8 @@ before:
     - go mod download
 
 builds:
-  - id: api-descriptor-scrubber
-    binary: api-descriptor-scrubber
+  - id: google-cloud-proto-scrubber
+    binary: google-cloud-proto-scrubber
     main: ./main.go
     env:
       - CGO_ENABLED=0

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ API Gateway][google-cloud-api-gateway].
 # Usage
 
 ```bash
-$ go run go.einride.tech/api-descriptor-scrubber -f descriptor.bin
+$ go run go.einride.tech/api-descriptor-scrubber -f descriptor.pb
 ```

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# API Descriptor Scrubber
+# Google Cloud Proto Scrubber
 
 [![PkgGoDev][pkg-badge]][pkg]
 [![GoReportCard][report-badge]][report]
 [![Codecov][codecov-badge]][codecov]
 
-[pkg-badge]: https://pkg.go.dev/badge/go.einride.tech/api-descriptor-scrubber
-[pkg]: https://pkg.go.dev/go.einride.tech/api-descriptor-scrubber
-[report-badge]: https://goreportcard.com/badge/go.einride.tech/api-descriptor-scrubber
-[report]: https://goreportcard.com/report/go.einride.tech/api-descriptor-scrubber
-[codecov-badge]: https://codecov.io/gh/einride/api-descriptor-scrubber-go/branch/master/graph/badge.svg
-[codecov]: https://codecov.io/gh/einride/api-descriptor-scrubber-go
+[pkg-badge]: https://pkg.go.dev/badge/go.einride.tech/google-cloud-proto-scrubber
+[pkg]: https://pkg.go.dev/go.einride.tech/google-cloud-proto-scrubber
+[report-badge]: https://goreportcard.com/badge/go.einride.tech/google-cloud-proto-scrubber
+[report]: https://goreportcard.com/report/go.einride.tech/google-cloud-proto-scrubber
+[codecov-badge]: https://codecov.io/gh/einride/google-cloud-proto-scrubber-go/branch/master/graph/badge.svg
+[codecov]: https://codecov.io/gh/einride/google-cloud-proto-scrubber
 
-Scrub gRPC API descriptors of unsupported annotations before uploading
+Scrub protobuf/gRPC API descriptors of unsupported annotations before uploading
 them to [Google Cloud Endpoints][google-cloud-endpoints] and [Google Cloud
 API Gateway][google-cloud-api-gateway].
 
@@ -21,5 +21,5 @@ API Gateway][google-cloud-api-gateway].
 # Usage
 
 ```bash
-$ go run go.einride.tech/api-descriptor-scrubber -f descriptor.pb
+$ go run go.einride.tech/google-cloud-proto-scrubber -f descriptor.pb
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.einride.tech/api-descriptor-scrubber
+module go.einride.tech/google-cloud-proto-scrubber
 
 go 1.15
 


### PR DESCRIPTION
Cloud Endpoints expects .pb suffix for binary protobuf descriptors.
